### PR TITLE
Add sleep personality test page

### DIFF
--- a/public/sleep-types/FMDC.svg
+++ b/public/sleep-types/FMDC.svg
@@ -1,0 +1,13 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 400'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#c6e5b1' />
+      <stop offset='100%' stop-color='#a7d7f2' />
+    </linearGradient>
+  </defs>
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='url(#grad)' />
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='rgba(255,255,255,0.35)' />
+  <text x='50%' y='50%' text-anchor='middle' dominant-baseline='central' font-size='140'>🦀</text>
+  <text x='50%' y='72%' text-anchor='middle' dominant-baseline='central' font-size='46' fill='#ffffff' font-family='sans-serif' font-weight='600' opacity='0.92'>FMDC</text>
+  <text x='50%' y='86%' text-anchor='middle' dominant-baseline='central' font-size='26' fill='#ffffff' font-family='sans-serif' opacity='0.85'>꿈속 탐험게</text>
+</svg>

--- a/public/sleep-types/FMDN.svg
+++ b/public/sleep-types/FMDN.svg
@@ -1,0 +1,13 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 400'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#f1d4e5' />
+      <stop offset='100%' stop-color='#b5e5f3' />
+    </linearGradient>
+  </defs>
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='url(#grad)' />
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='rgba(255,255,255,0.35)' />
+  <text x='50%' y='50%' text-anchor='middle' dominant-baseline='central' font-size='140'>🦀</text>
+  <text x='50%' y='72%' text-anchor='middle' dominant-baseline='central' font-size='46' fill='#ffffff' font-family='sans-serif' font-weight='600' opacity='0.92'>FMDN</text>
+  <text x='50%' y='86%' text-anchor='middle' dominant-baseline='central' font-size='26' fill='#ffffff' font-family='sans-serif' opacity='0.85'>폭풍 돌잠게</text>
+</svg>

--- a/public/sleep-types/FMSC.svg
+++ b/public/sleep-types/FMSC.svg
@@ -1,0 +1,13 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 400'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#a6d7d3' />
+      <stop offset='100%' stop-color='#f4d4ef' />
+    </linearGradient>
+  </defs>
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='url(#grad)' />
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='rgba(255,255,255,0.35)' />
+  <text x='50%' y='50%' text-anchor='middle' dominant-baseline='central' font-size='140'>🦀</text>
+  <text x='50%' y='72%' text-anchor='middle' dominant-baseline='central' font-size='46' fill='#ffffff' font-family='sans-serif' font-weight='600' opacity='0.92'>FMSC</text>
+  <text x='50%' y='86%' text-anchor='middle' dominant-baseline='central' font-size='26' fill='#ffffff' font-family='sans-serif' opacity='0.85'>몽환 예민게</text>
+</svg>

--- a/public/sleep-types/FMSN.svg
+++ b/public/sleep-types/FMSN.svg
@@ -1,0 +1,13 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 400'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#f7d6c3' />
+      <stop offset='100%' stop-color='#c3e7f4' />
+    </linearGradient>
+  </defs>
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='url(#grad)' />
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='rgba(255,255,255,0.35)' />
+  <text x='50%' y='50%' text-anchor='middle' dominant-baseline='central' font-size='140'>🦀</text>
+  <text x='50%' y='72%' text-anchor='middle' dominant-baseline='central' font-size='46' fill='#ffffff' font-family='sans-serif' font-weight='600' opacity='0.92'>FMSN</text>
+  <text x='50%' y='86%' text-anchor='middle' dominant-baseline='central' font-size='26' fill='#ffffff' font-family='sans-serif' opacity='0.85'>불안정 단잠게</text>
+</svg>

--- a/public/sleep-types/FQDC.svg
+++ b/public/sleep-types/FQDC.svg
@@ -1,0 +1,13 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 400'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#c6e5b1' />
+      <stop offset='100%' stop-color='#a7d7f2' />
+    </linearGradient>
+  </defs>
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='url(#grad)' />
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='rgba(255,255,255,0.35)' />
+  <text x='50%' y='50%' text-anchor='middle' dominant-baseline='central' font-size='140'>🦀</text>
+  <text x='50%' y='72%' text-anchor='middle' dominant-baseline='central' font-size='46' fill='#ffffff' font-family='sans-serif' font-weight='600' opacity='0.92'>FQDC</text>
+  <text x='50%' y='86%' text-anchor='middle' dominant-baseline='central' font-size='26' fill='#ffffff' font-family='sans-serif' opacity='0.85'>몽중 철인게</text>
+</svg>

--- a/public/sleep-types/FQDN.svg
+++ b/public/sleep-types/FQDN.svg
@@ -1,0 +1,13 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 400'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#f1d4e5' />
+      <stop offset='100%' stop-color='#b5e5f3' />
+    </linearGradient>
+  </defs>
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='url(#grad)' />
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='rgba(255,255,255,0.35)' />
+  <text x='50%' y='50%' text-anchor='middle' dominant-baseline='central' font-size='140'>🦀</text>
+  <text x='50%' y='72%' text-anchor='middle' dominant-baseline='central' font-size='46' fill='#ffffff' font-family='sans-serif' font-weight='600' opacity='0.92'>FQDN</text>
+  <text x='50%' y='86%' text-anchor='middle' dominant-baseline='central' font-size='26' fill='#ffffff' font-family='sans-serif' opacity='0.85'>철벽 돌잠게</text>
+</svg>

--- a/public/sleep-types/FQSC.svg
+++ b/public/sleep-types/FQSC.svg
@@ -1,0 +1,13 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 400'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#a6d7d3' />
+      <stop offset='100%' stop-color='#f4d4ef' />
+    </linearGradient>
+  </defs>
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='url(#grad)' />
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='rgba(255,255,255,0.35)' />
+  <text x='50%' y='50%' text-anchor='middle' dominant-baseline='central' font-size='140'>🦀</text>
+  <text x='50%' y='72%' text-anchor='middle' dominant-baseline='central' font-size='46' fill='#ffffff' font-family='sans-serif' font-weight='600' opacity='0.92'>FQSC</text>
+  <text x='50%' y='86%' text-anchor='middle' dominant-baseline='central' font-size='26' fill='#ffffff' font-family='sans-serif' opacity='0.85'>새털몽게</text>
+</svg>

--- a/public/sleep-types/FQSN.svg
+++ b/public/sleep-types/FQSN.svg
@@ -1,0 +1,13 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 400'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#f7d6c3' />
+      <stop offset='100%' stop-color='#c3e7f4' />
+    </linearGradient>
+  </defs>
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='url(#grad)' />
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='rgba(255,255,255,0.35)' />
+  <text x='50%' y='50%' text-anchor='middle' dominant-baseline='central' font-size='140'>🦀</text>
+  <text x='50%' y='72%' text-anchor='middle' dominant-baseline='central' font-size='46' fill='#ffffff' font-family='sans-serif' font-weight='600' opacity='0.92'>FQSN</text>
+  <text x='50%' y='86%' text-anchor='middle' dominant-baseline='central' font-size='26' fill='#ffffff' font-family='sans-serif' opacity='0.85'>고요 예민게</text>
+</svg>

--- a/public/sleep-types/LMDC.svg
+++ b/public/sleep-types/LMDC.svg
@@ -1,0 +1,13 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 400'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#c6e5b1' />
+      <stop offset='100%' stop-color='#a7d7f2' />
+    </linearGradient>
+  </defs>
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='url(#grad)' />
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='rgba(255,255,255,0.35)' />
+  <text x='50%' y='50%' text-anchor='middle' dominant-baseline='central' font-size='140'>🦀</text>
+  <text x='50%' y='72%' text-anchor='middle' dominant-baseline='central' font-size='46' fill='#ffffff' font-family='sans-serif' font-weight='600' opacity='0.92'>LMDC</text>
+  <text x='50%' y='86%' text-anchor='middle' dominant-baseline='central' font-size='26' fill='#ffffff' font-family='sans-serif' opacity='0.85'>불안정 몽환게</text>
+</svg>

--- a/public/sleep-types/LMDN.svg
+++ b/public/sleep-types/LMDN.svg
@@ -1,0 +1,13 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 400'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#f1d4e5' />
+      <stop offset='100%' stop-color='#b5e5f3' />
+    </linearGradient>
+  </defs>
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='url(#grad)' />
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='rgba(255,255,255,0.35)' />
+  <text x='50%' y='50%' text-anchor='middle' dominant-baseline='central' font-size='140'>🦀</text>
+  <text x='50%' y='72%' text-anchor='middle' dominant-baseline='central' font-size='46' fill='#ffffff' font-family='sans-serif' font-weight='600' opacity='0.92'>LMDN</text>
+  <text x='50%' y='86%' text-anchor='middle' dominant-baseline='central' font-size='26' fill='#ffffff' font-family='sans-serif' opacity='0.85'>야행 돌잠게</text>
+</svg>

--- a/public/sleep-types/LMSC.svg
+++ b/public/sleep-types/LMSC.svg
@@ -1,0 +1,13 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 400'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#a6d7d3' />
+      <stop offset='100%' stop-color='#f4d4ef' />
+    </linearGradient>
+  </defs>
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='url(#grad)' />
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='rgba(255,255,255,0.35)' />
+  <text x='50%' y='50%' text-anchor='middle' dominant-baseline='central' font-size='140'>🦀</text>
+  <text x='50%' y='72%' text-anchor='middle' dominant-baseline='central' font-size='46' fill='#ffffff' font-family='sans-serif' font-weight='600' opacity='0.92'>LMSC</text>
+  <text x='50%' y='86%' text-anchor='middle' dominant-baseline='central' font-size='26' fill='#ffffff' font-family='sans-serif' opacity='0.85'>뒤척몽게</text>
+</svg>

--- a/public/sleep-types/LMSN.svg
+++ b/public/sleep-types/LMSN.svg
@@ -1,0 +1,13 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 400'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#f7d6c3' />
+      <stop offset='100%' stop-color='#c3e7f4' />
+    </linearGradient>
+  </defs>
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='url(#grad)' />
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='rgba(255,255,255,0.35)' />
+  <text x='50%' y='50%' text-anchor='middle' dominant-baseline='central' font-size='140'>🦀</text>
+  <text x='50%' y='72%' text-anchor='middle' dominant-baseline='central' font-size='46' fill='#ffffff' font-family='sans-serif' font-weight='600' opacity='0.92'>LMSN</text>
+  <text x='50%' y='86%' text-anchor='middle' dominant-baseline='central' font-size='26' fill='#ffffff' font-family='sans-serif' opacity='0.85'>뒤척 예민게</text>
+</svg>

--- a/public/sleep-types/LQDC.svg
+++ b/public/sleep-types/LQDC.svg
@@ -1,0 +1,13 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 400'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#c6e5b1' />
+      <stop offset='100%' stop-color='#a7d7f2' />
+    </linearGradient>
+  </defs>
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='url(#grad)' />
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='rgba(255,255,255,0.35)' />
+  <text x='50%' y='50%' text-anchor='middle' dominant-baseline='central' font-size='140'>🦀</text>
+  <text x='50%' y='72%' text-anchor='middle' dominant-baseline='central' font-size='46' fill='#ffffff' font-family='sans-serif' font-weight='600' opacity='0.92'>LQDC</text>
+  <text x='50%' y='86%' text-anchor='middle' dominant-baseline='central' font-size='26' fill='#ffffff' font-family='sans-serif' opacity='0.85'>몽속 잠꾸러기게</text>
+</svg>

--- a/public/sleep-types/LQDN.svg
+++ b/public/sleep-types/LQDN.svg
@@ -1,0 +1,13 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 400'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#f1d4e5' />
+      <stop offset='100%' stop-color='#b5e5f3' />
+    </linearGradient>
+  </defs>
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='url(#grad)' />
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='rgba(255,255,255,0.35)' />
+  <text x='50%' y='50%' text-anchor='middle' dominant-baseline='central' font-size='140'>🦀</text>
+  <text x='50%' y='72%' text-anchor='middle' dominant-baseline='central' font-size='46' fill='#ffffff' font-family='sans-serif' font-weight='600' opacity='0.92'>LQDN</text>
+  <text x='50%' y='86%' text-anchor='middle' dominant-baseline='central' font-size='26' fill='#ffffff' font-family='sans-serif' opacity='0.85'>돌잠 마스터게</text>
+</svg>

--- a/public/sleep-types/LQSC.svg
+++ b/public/sleep-types/LQSC.svg
@@ -1,0 +1,13 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 400'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#a6d7d3' />
+      <stop offset='100%' stop-color='#f4d4ef' />
+    </linearGradient>
+  </defs>
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='url(#grad)' />
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='rgba(255,255,255,0.35)' />
+  <text x='50%' y='50%' text-anchor='middle' dominant-baseline='central' font-size='140'>🦀</text>
+  <text x='50%' y='72%' text-anchor='middle' dominant-baseline='central' font-size='46' fill='#ffffff' font-family='sans-serif' font-weight='600' opacity='0.92'>LQSC</text>
+  <text x='50%' y='86%' text-anchor='middle' dominant-baseline='central' font-size='26' fill='#ffffff' font-family='sans-serif' opacity='0.85'>고요 몽환게</text>
+</svg>

--- a/public/sleep-types/LQSN.svg
+++ b/public/sleep-types/LQSN.svg
@@ -1,0 +1,13 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 400'>
+  <defs>
+    <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#f7d6c3' />
+      <stop offset='100%' stop-color='#c3e7f4' />
+    </linearGradient>
+  </defs>
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='url(#grad)' />
+  <rect x='12' y='12' width='376' height='376' rx='68' fill='rgba(255,255,255,0.35)' />
+  <text x='50%' y='50%' text-anchor='middle' dominant-baseline='central' font-size='140'>🦀</text>
+  <text x='50%' y='72%' text-anchor='middle' dominant-baseline='central' font-size='46' fill='#ffffff' font-family='sans-serif' font-weight='600' opacity='0.92'>LQSN</text>
+  <text x='50%' y='86%' text-anchor='middle' dominant-baseline='central' font-size='26' fill='#ffffff' font-family='sans-serif' opacity='0.85'>고요 예민게(야행)</text>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import HomePage from "./pages/HomePage";
 import ShisenSho from "./pages/ShisenSho";
 import CrabMemory from "./pages/CrabMemory";
 import OceanRun from "./pages/OceanRun";
+import SleepTest from "./pages/SleepTest";
 
 const App = () => {
   return (
@@ -17,6 +18,7 @@ const App = () => {
           <Route path="/shisen-sho" element={<ShisenSho />} />
           <Route path="/crab-memory" element={<CrabMemory />} />
           <Route path="/ocean-run" element={<OceanRun />} />
+          <Route path="/sleep-test" element={<SleepTest />} />
         </Routes>
       </Router>
     </ThemeProvider>

--- a/src/components/SleepKakaoShareButton.jsx
+++ b/src/components/SleepKakaoShareButton.jsx
@@ -1,0 +1,75 @@
+import React from "react";
+import styled from "styled-components";
+import kakao_ico from "../assets/images/kakao_ico.png"; // Corrected import statement
+
+const { Kakao } = window;
+
+const SleepKakaoShareButton = ({ sleepResult }) => {
+  const url = "https://crab-game.sparkling-rae.com/sleep-test";
+  const resultUrl = window.location.href;
+  React.useEffect(() => {
+    try {
+      if (!Kakao.isInitialized()) {
+        Kakao.init("c26d1dfad60d03492f69054ba08132b1");
+        Kakao.isInitialized();
+        console.log("Kakao is initialized");
+      } else {
+        console.log("Kakao is already initialized");
+      }
+    } catch (error) {
+      console.log("Kakao is not initialized");
+      console.error(error);
+    }
+  }, []);
+  const description = sleepResult.name + " / " + sleepResult.desc;
+  const shareKakao = () => {
+    Kakao.Link.sendDefault({
+      objectType: "feed",
+      content: {
+        title: "내 수면타입 알아보게",
+        description: description,
+        imageUrl: sleepResult.image,
+        link: {
+          mobileWebUrl: resultUrl,
+          webUrl: resultUrl,
+        },
+      },
+      buttons: [
+        {
+          title: "내 수면타입 알아보게 놀러가기",
+          link: {
+            mobileWebUrl: url,
+            webUrl: url,
+          },
+        },
+      ],
+    });
+  };
+
+  return (
+    <>
+      <Button onClick={shareKakao}>
+        공유하기 <img src={kakao_ico} alt="kakao_ico" width={30} height={35} />{" "}
+      </Button>
+    </>
+  );
+};
+
+export default SleepKakaoShareButton;
+const Button = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  align-content: center;
+  padding: 10px;
+  padding-left: 25px;
+  padding-right: 25px;
+  border-radius: 25px; // 패딩을 70%로 조정
+  color: #3a1c1c;
+  font-size: 1rem; // 폰트 크기를 70%로 조정
+  background-color: #fae301;
+  cursor: pointer;
+  word-break: keep-all;
+  // 여백을 70%로 조정
+  font-family: "DoHyeon-Regular";
+`;

--- a/src/constants/sleepTestData.ts
+++ b/src/constants/sleepTestData.ts
@@ -1,0 +1,193 @@
+export type SleepAxis = "FL" | "MQ" | "SD" | "CN";
+
+export type SleepLetter = "F" | "L" | "M" | "Q" | "S" | "D" | "C" | "N";
+
+export const AXIS_ORDER: SleepAxis[] = ["FL", "MQ", "SD", "CN"];
+
+export const AXIS_LETTER_MAP: Record<SleepAxis, [SleepLetter, SleepLetter]> = {
+  FL: ["F", "L"],
+  MQ: ["M", "Q"],
+  SD: ["S", "D"],
+  CN: ["C", "N"],
+};
+
+export type SleepQuestion = {
+  id: number;
+  text: string;
+  axis: SleepAxis;
+  yes: SleepLetter;
+};
+
+export const SLEEP_QUESTIONS: SleepQuestion[] = [
+  { id: 1, text: "나는 눕자마자 금방 잠드는 편이다.", axis: "FL", yes: "F" },
+  { id: 2, text: "잠들기까지 20분 이상 걸리는 편이다.", axis: "FL", yes: "L" },
+  { id: 3, text: "낮잠도 쉽게 든다.", axis: "FL", yes: "F" },
+  {
+    id: 4,
+    text: "잠들기 전에 생각이 많아 쉽게 못 잔다.",
+    axis: "FL",
+    yes: "L",
+  },
+  {
+    id: 5,
+    text: "자면서 이불을 자주 걷어차거나 말아버린다.",
+    axis: "MQ",
+    yes: "M",
+  },
+  {
+    id: 6,
+    text: "자고 일어나면 베개나 자세가 자주 바뀌어 있다.",
+    axis: "MQ",
+    yes: "M",
+  },
+  { id: 7, text: "나는 같은 자세로 오랫동안 고요하게 잔다.", axis: "MQ", yes: "Q" },
+  {
+    id: 8,
+    text: "나의 수면은 주변에 방해가 되지 않을 만큼 조용하다.",
+    axis: "MQ",
+    yes: "Q",
+  },
+  { id: 9, text: "작은 소리에도 쉽게 잠에서 깬다.", axis: "SD", yes: "S" },
+  { id: 10, text: "누가 살짝 건드려도 잠에서 깬다.", axis: "SD", yes: "S" },
+  {
+    id: 11,
+    text: "알람이 울려도 못 듣고 자는 경우가 있다.",
+    axis: "SD",
+    yes: "D",
+  },
+  { id: 12, text: "불빛이나 소음이 있어도 푹 잘 잔다.", axis: "SD", yes: "D" },
+  { id: 13, text: "나는 꿈을 자주 기억한다.", axis: "CN", yes: "C" },
+  {
+    id: 14,
+    text: "내 꿈은 종종 생생해서 영화처럼 느껴진다.",
+    axis: "CN",
+    yes: "C",
+  },
+  { id: 15, text: "아침에 일어나면 꿈을 거의 기억 못 한다.", axis: "CN", yes: "N" },
+  { id: 16, text: "나는 꿈을 잘 꾸지 않는 편이다.", axis: "CN", yes: "N" },
+];
+
+export type SleepResultType = {
+  code: string;
+  name: string;
+  desc: string;
+  tip: string;
+  image: string;
+};
+
+export const SLEEP_RESULT_TYPES: SleepResultType[] = [
+  {
+    code: "FMSC",
+    name: "몽환 예민게",
+    desc: "금방 잠들지만 꿈틀, 꿈을 자주 꾸며 건드리면 쉽게 깨는 타입",
+    tip: "귀마개와 안대를 챙기면 수면의 질이 확 좋아져요.",
+    image: "/sleep-types/FMSC.svg",
+  },
+  {
+    code: "FMSN",
+    name: "불안정 단잠게",
+    desc: "금방 잠들고 뒤척이지만 꿈은 없고 예민해서 쉽게 깸",
+    tip: "베개 높이/매트리스 탄성 점검으로 뒤척임을 줄여보세요.",
+    image: "/sleep-types/FMSN.svg",
+  },
+  {
+    code: "FMDC",
+    name: "꿈속 탐험게",
+    desc: "금방 잠들고 뒤척이며 깊은 잠에 빠져 꿈을 선명히 꾸는 타입",
+    tip: "자기 전 가벼운 독서로 즐거운 꿈을 세팅해보세요.",
+    image: "/sleep-types/FMDC.svg",
+  },
+  {
+    code: "FMDN",
+    name: "폭풍 돌잠게",
+    desc: "금방 잠들고 꿈도 없으며 뒤척여도 절대 안 깨는 강철 수면러",
+    tip: "알람은 2개 이상! 기상 루틴을 확실히 만드세요.",
+    image: "/sleep-types/FMDN.svg",
+  },
+  {
+    code: "FQSC",
+    name: "새털몽게",
+    desc: "고요하게 금방 잠들고 꿈을 잘 꾸지만 작은 자극에도 금방 깸",
+    tip: "백색소음이나 가벼운 음악으로 미세한 소음을 덮어주세요.",
+    image: "/sleep-types/FQSC.svg",
+  },
+  {
+    code: "FQSN",
+    name: "고요 예민게",
+    desc: "조용히 금방 잠들지만 꿈은 없고 예민하게 잘 깸",
+    tip: "수면 마스크 + 암막 커튼으로 빛 차단을 추천해요.",
+    image: "/sleep-types/FQSN.svg",
+  },
+  {
+    code: "FQDC",
+    name: "몽중 철인게",
+    desc: "고요하게 깊게 자며 생생한 꿈을 꾸는 강철 수면러",
+    tip: "침실 온도/습도만 잘 맞추면 최강 컨디션 유지!",
+    image: "/sleep-types/FQDC.svg",
+  },
+  {
+    code: "FQDN",
+    name: "철벽 돌잠게",
+    desc: "고요히 푹 자고 꿈도 없으며 절대 안 깨는 최강 수면러",
+    tip: "수면 시간이 너무 길어지지 않게 기상 알림을 분산해두세요.",
+    image: "/sleep-types/FQDN.svg",
+  },
+  {
+    code: "LMSC",
+    name: "뒤척몽게",
+    desc: "늦게 자고 뒤척이며 꿈도 자주 꾸고 예민하게 깨는 타입",
+    tip: "자기 전 스트레칭으로 긴장을 풀고 루틴을 고정하세요.",
+    image: "/sleep-types/LMSC.svg",
+  },
+  {
+    code: "LMSN",
+    name: "뒤척 예민게",
+    desc: "늦게 잠들고 꿈도 없지만 뒤척이고 쉽게 깸",
+    tip: "카페인/당류 섭취 시간대를 앞당겨보세요.",
+    image: "/sleep-types/LMSN.svg",
+  },
+  {
+    code: "LMDC",
+    name: "불안정 몽환게",
+    desc: "늦게 자고 뒤척이지만 깊은 잠에 빠져 꿈을 선명히 꾸는 타입",
+    tip: "자기 전 스크린 타임을 1시간 줄여보세요.",
+    image: "/sleep-types/LMDC.svg",
+  },
+  {
+    code: "LMDN",
+    name: "야행 돌잠게",
+    desc: "늦게 자고 뒤척이지만 꿈도 없고 절대 안 깨는 타입",
+    tip: "수면-기상 시간을 주 단위로 조금씩 앞당겨보세요.",
+    image: "/sleep-types/LMDN.svg",
+  },
+  {
+    code: "LQSC",
+    name: "고요 몽환게",
+    desc: "늦게 자고 조용히 꿈을 꾸지만 예민해서 쉽게 깸",
+    tip: "수면 환경(온도/소음/빛) 체크리스트를 만들어보세요.",
+    image: "/sleep-types/LQSC.svg",
+  },
+  {
+    code: "LQSN",
+    name: "고요 예민게(야행)",
+    desc: "늦게 자고 조용하지만 꿈도 없고 예민하게 깨는 타입",
+    tip: "자가 마사지나 따뜻한 샤워로 이완하세요.",
+    image: "/sleep-types/LQSN.svg",
+  },
+  {
+    code: "LQDC",
+    name: "몽속 잠꾸러기게",
+    desc: "늦게 자고 고요히 깊은 잠에 빠져 꿈도 자주 꾸는 타입",
+    tip: "일정한 취침 알림으로 시작 신호를 뇌에 학습시키세요.",
+    image: "/sleep-types/LQDC.svg",
+  },
+  {
+    code: "LQDN",
+    name: "돌잠 마스터게",
+    desc: "늦게 자고 고요하며 꿈도 없고 절대 안 깸",
+    tip: "기상 후 햇빛 10분으로 리듬을 리셋해보세요.",
+    image: "/sleep-types/LQDN.svg",
+  },
+];
+
+export const SLEEP_CHARACTER_EMOJI = "🦀";

--- a/src/constants/sleepTestData.ts
+++ b/src/constants/sleepTestData.ts
@@ -18,6 +18,30 @@ export type SleepQuestion = {
   yes: SleepLetter;
 };
 
+/* 
+💤 수면구분법 최종 축
+
+잠드는 속도:
+
+F (Fast): 금방 잠듦
+L (Late): 늦게 겨우 잠듦
+
+잠버릇:
+
+M (Mover): 많이 뒤척임
+Q (Quiet): 조용히 잠
+
+예민도:
+
+S (Sensitive): 쉽게 깸
+D (Deep): 잘 안 깸
+
+꿈 성향:
+
+C (Clear): 꿈을 자주 꾸고 기억함
+N (No-dream): 꿈을 잘 안 꾸거나 기억 못함
+
+*/
 export const SLEEP_QUESTIONS: SleepQuestion[] = [
   { id: 1, text: "나는 눕자마자 금방 잠드는 편이다.", axis: "FL", yes: "F" },
   { id: 2, text: "잠들기까지 20분 이상 걸리는 편이다.", axis: "FL", yes: "L" },
@@ -40,7 +64,12 @@ export const SLEEP_QUESTIONS: SleepQuestion[] = [
     axis: "MQ",
     yes: "M",
   },
-  { id: 7, text: "나는 같은 자세로 오랫동안 고요하게 잔다.", axis: "MQ", yes: "Q" },
+  {
+    id: 7,
+    text: "나는 같은 자세로 오랫동안 고요하게 잔다.",
+    axis: "MQ",
+    yes: "Q",
+  },
   {
     id: 8,
     text: "나의 수면은 주변에 방해가 되지 않을 만큼 조용하다.",
@@ -63,7 +92,12 @@ export const SLEEP_QUESTIONS: SleepQuestion[] = [
     axis: "CN",
     yes: "C",
   },
-  { id: 15, text: "아침에 일어나면 꿈을 거의 기억 못 한다.", axis: "CN", yes: "N" },
+  {
+    id: 15,
+    text: "아침에 일어나면 꿈을 거의 기억 못 한다.",
+    axis: "CN",
+    yes: "N",
+  },
   { id: 16, text: "나는 꿈을 잘 꾸지 않는 편이다.", axis: "CN", yes: "N" },
 ];
 
@@ -81,112 +115,128 @@ export const SLEEP_RESULT_TYPES: SleepResultType[] = [
     name: "몽환 예민게",
     desc: "금방 잠들지만 꿈틀, 꿈을 자주 꾸며 건드리면 쉽게 깨는 타입",
     tip: "귀마개와 안대를 챙기면 수면의 질이 확 좋아져요.",
-    image: "/sleep-types/FMSC.svg",
+    image:
+      "https://assets.sparkling-rae.com/crab-game/sleep-type-webp/FMSC.webp",
   },
   {
     code: "FMSN",
     name: "불안정 단잠게",
     desc: "금방 잠들고 뒤척이지만 꿈은 없고 예민해서 쉽게 깸",
     tip: "베개 높이/매트리스 탄성 점검으로 뒤척임을 줄여보세요.",
-    image: "/sleep-types/FMSN.svg",
+    image:
+      "https://assets.sparkling-rae.com/crab-game/sleep-type-webp/FMSN.webp",
   },
   {
     code: "FMDC",
     name: "꿈속 탐험게",
     desc: "금방 잠들고 뒤척이며 깊은 잠에 빠져 꿈을 선명히 꾸는 타입",
     tip: "자기 전 가벼운 독서로 즐거운 꿈을 세팅해보세요.",
-    image: "/sleep-types/FMDC.svg",
+    image:
+      "https://assets.sparkling-rae.com/crab-game/sleep-type-webp/FMDC.webp",
   },
   {
     code: "FMDN",
     name: "폭풍 돌잠게",
     desc: "금방 잠들고 꿈도 없으며 뒤척여도 절대 안 깨는 강철 수면러",
     tip: "알람은 2개 이상! 기상 루틴을 확실히 만드세요.",
-    image: "/sleep-types/FMDN.svg",
+    image:
+      "https://assets.sparkling-rae.com/crab-game/sleep-type-webp/FMDN.webp",
   },
   {
     code: "FQSC",
     name: "새털몽게",
     desc: "고요하게 금방 잠들고 꿈을 잘 꾸지만 작은 자극에도 금방 깸",
     tip: "백색소음이나 가벼운 음악으로 미세한 소음을 덮어주세요.",
-    image: "/sleep-types/FQSC.svg",
+    image:
+      "https://assets.sparkling-rae.com/crab-game/sleep-type-webp/FQSC.webp",
   },
   {
     code: "FQSN",
     name: "고요 예민게",
     desc: "조용히 금방 잠들지만 꿈은 없고 예민하게 잘 깸",
     tip: "수면 마스크 + 암막 커튼으로 빛 차단을 추천해요.",
-    image: "/sleep-types/FQSN.svg",
+    image:
+      "https://assets.sparkling-rae.com/crab-game/sleep-type-webp/FQSN.webp",
   },
   {
     code: "FQDC",
     name: "몽중 철인게",
     desc: "고요하게 깊게 자며 생생한 꿈을 꾸는 강철 수면러",
     tip: "침실 온도/습도만 잘 맞추면 최강 컨디션 유지!",
-    image: "/sleep-types/FQDC.svg",
+    image:
+      "https://assets.sparkling-rae.com/crab-game/sleep-type-webp/FQDC.webp",
   },
   {
     code: "FQDN",
     name: "철벽 돌잠게",
     desc: "고요히 푹 자고 꿈도 없으며 절대 안 깨는 최강 수면러",
     tip: "수면 시간이 너무 길어지지 않게 기상 알림을 분산해두세요.",
-    image: "/sleep-types/FQDN.svg",
+    image:
+      "https://assets.sparkling-rae.com/crab-game/sleep-type-webp/FQDN.webp",
   },
   {
     code: "LMSC",
     name: "뒤척몽게",
     desc: "늦게 자고 뒤척이며 꿈도 자주 꾸고 예민하게 깨는 타입",
     tip: "자기 전 스트레칭으로 긴장을 풀고 루틴을 고정하세요.",
-    image: "/sleep-types/LMSC.svg",
+    image:
+      "https://assets.sparkling-rae.com/crab-game/sleep-type-webp/LMSC.webp",
   },
   {
     code: "LMSN",
     name: "뒤척 예민게",
     desc: "늦게 잠들고 꿈도 없지만 뒤척이고 쉽게 깸",
     tip: "카페인/당류 섭취 시간대를 앞당겨보세요.",
-    image: "/sleep-types/LMSN.svg",
+    image:
+      "https://assets.sparkling-rae.com/crab-game/sleep-type-webp/LMSN.webp",
   },
   {
     code: "LMDC",
     name: "불안정 몽환게",
     desc: "늦게 자고 뒤척이지만 깊은 잠에 빠져 꿈을 선명히 꾸는 타입",
     tip: "자기 전 스크린 타임을 1시간 줄여보세요.",
-    image: "/sleep-types/LMDC.svg",
+    image:
+      "https://assets.sparkling-rae.com/crab-game/sleep-type-webp/LMDC.webp",
   },
   {
     code: "LMDN",
     name: "야행 돌잠게",
     desc: "늦게 자고 뒤척이지만 꿈도 없고 절대 안 깨는 타입",
     tip: "수면-기상 시간을 주 단위로 조금씩 앞당겨보세요.",
-    image: "/sleep-types/LMDN.svg",
+    image:
+      "https://assets.sparkling-rae.com/crab-game/sleep-type-webp/LMDN.webp",
   },
   {
     code: "LQSC",
     name: "고요 몽환게",
     desc: "늦게 자고 조용히 꿈을 꾸지만 예민해서 쉽게 깸",
     tip: "수면 환경(온도/소음/빛) 체크리스트를 만들어보세요.",
-    image: "/sleep-types/LQSC.svg",
+    image:
+      "https://assets.sparkling-rae.com/crab-game/sleep-type-webp/LQSC.webp",
   },
   {
     code: "LQSN",
     name: "고요 예민게(야행)",
     desc: "늦게 자고 조용하지만 꿈도 없고 예민하게 깨는 타입",
     tip: "자가 마사지나 따뜻한 샤워로 이완하세요.",
-    image: "/sleep-types/LQSN.svg",
+    image:
+      "https://assets.sparkling-rae.com/crab-game/sleep-type-webp/LQSN.webp",
   },
   {
     code: "LQDC",
     name: "몽속 잠꾸러기게",
     desc: "늦게 자고 고요히 깊은 잠에 빠져 꿈도 자주 꾸는 타입",
     tip: "일정한 취침 알림으로 시작 신호를 뇌에 학습시키세요.",
-    image: "/sleep-types/LQDC.svg",
+    image:
+      "https://assets.sparkling-rae.com/crab-game/sleep-type-webp/LQDC.webp",
   },
   {
     code: "LQDN",
     name: "돌잠 마스터게",
     desc: "늦게 자고 고요하며 꿈도 없고 절대 안 깸",
     tip: "기상 후 햇빛 10분으로 리듬을 리셋해보세요.",
-    image: "/sleep-types/LQDN.svg",
+    image:
+      "https://assets.sparkling-rae.com/crab-game/sleep-type-webp/LQDN.webp",
   },
 ];
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -158,25 +158,40 @@ const HomePage = () => {
       <Title>베게네 오락실</Title>
       <LogoImage src={crab_game_logo} alt="베게네 오락실" />
       <GameGrid>
-        <GameCard to="/shisen-sho">
+        <GameCard to="/sleep-test">
+          <GameTitle>
+            <img
+              src={"https://assets.sparkling-rae.com/crab-game/sleep-crab.png"}
+              width={72}
+              height={72}
+              alt="내 수면타입 알아보게"
+            />
+            수면구분법 테스트
+          </GameTitle>
+          <GameDescription>
+            잠버릇으로 알아보는 나의 게 타입!
+            <br />
+            16문항 테스트로 수면 팁을 받아보세요.
+          </GameDescription>
+        </GameCard>
+        <GameCard to="/ocean-run">
           <GameTitle>
             <img
               src={
-                "https://assets.sparkling-rae.com/crab-game/crab-shisen-sho.webp"
+                "https://assets.sparkling-rae.com/crab-game/crab-ocean-run.png"
               }
               width={72}
               height={72}
-              alt="사천성"
+              alt="오션 런"
             />
-            사천성
+            오션 런
           </GameTitle>
           <GameDescription>
-            귀여운 베게들과 함께하는
+            바닷가를 헤엄치는 베게
             <br />
-            전통 사천성 게임!
+            장애물들을 피해 기록을 세워보게
           </GameDescription>
         </GameCard>
-
         <GameCard to="/crab-memory">
           <GameTitle>
             <img
@@ -193,18 +208,22 @@ const HomePage = () => {
             다양한 난이도와 타이머에 도전하세요.
           </GameDescription>
         </GameCard>
-
-        <GameCard to="/sleep-test">
+        <GameCard to="/shisen-sho">
           <GameTitle>
-            <GameEmoji role="img" aria-label="수면구분법 테스트">
-              🦀
-            </GameEmoji>
-            수면구분법 테스트
+            <img
+              src={
+                "https://assets.sparkling-rae.com/crab-game/crab-shisen-sho.webp"
+              }
+              width={72}
+              height={72}
+              alt="사천성"
+            />
+            사천성
           </GameTitle>
           <GameDescription>
-            잠버릇으로 알아보는 나의 게 타입!
+            귀여운 베게들과 함께하는
             <br />
-            16문항 테스트로 수면 팁을 받아보세요.
+            전통 사천성 게임!
           </GameDescription>
         </GameCard>
       </GameGrid>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -193,6 +193,20 @@ const HomePage = () => {
             다양한 난이도와 타이머에 도전하세요.
           </GameDescription>
         </GameCard>
+
+        <GameCard to="/sleep-test">
+          <GameTitle>
+            <GameEmoji role="img" aria-label="수면구분법 테스트">
+              🦀
+            </GameEmoji>
+            수면구분법 테스트
+          </GameTitle>
+          <GameDescription>
+            잠버릇으로 알아보는 나의 게 타입!
+            <br />
+            16문항 테스트로 수면 팁을 받아보세요.
+          </GameDescription>
+        </GameCard>
       </GameGrid>
     </HomeContainer>
   );

--- a/src/pages/SleepTest.tsx
+++ b/src/pages/SleepTest.tsx
@@ -4,12 +4,12 @@ import styled from "styled-components";
 import {
   AXIS_LETTER_MAP,
   AXIS_ORDER,
-  SLEEP_CHARACTER_EMOJI,
   SLEEP_QUESTIONS,
   SLEEP_RESULT_TYPES,
   SleepLetter,
   SleepResultType,
 } from "../constants/sleepTestData";
+import SleepKakaoShareButton from "../components/SleepKakaoShareButton";
 
 type Stage = "intro" | "quiz" | "result";
 
@@ -64,7 +64,8 @@ const SleepTest = () => {
 
     const axisLetters = AXIS_LETTER_MAP[currentQuestion.axis];
     const yesLetter = currentQuestion.yes;
-    const noLetter = axisLetters[0] === yesLetter ? axisLetters[1] : axisLetters[0];
+    const noLetter =
+      axisLetters[0] === yesLetter ? axisLetters[1] : axisLetters[0];
     const selectedLetter = isYes ? yesLetter : noLetter;
 
     const updatedScores = {
@@ -90,10 +91,13 @@ const SleepTest = () => {
       <Content>
         {stage === "intro" && (
           <IntroCard>
-            <IntroTitle>🦀 수면구분법 테스트</IntroTitle>
-            <IntroDescription>
-              나는 어떤 잠버릇 타입일까? 총 16문항으로 알아보는 수면 성격 테스트!
-            </IntroDescription>
+            <img
+              src={"https://assets.sparkling-rae.com/crab-game/sleep-crab.png"}
+              width={300}
+              height={300}
+              alt="내 수면타입 알아보게"
+            />
+            <IntroTitle>내 수면타입 알아보게</IntroTitle>
             <StartButton type="button" onClick={handleStart}>
               시작하기
             </StartButton>
@@ -117,7 +121,11 @@ const SleepTest = () => {
               <OptionButton type="button" onClick={() => handleAnswer(true)}>
                 예
               </OptionButton>
-              <OptionButton type="button" $variant="outline" onClick={() => handleAnswer(false)}>
+              <OptionButton
+                type="button"
+                $variant="outline"
+                onClick={() => handleAnswer(false)}
+              >
                 아니오
               </OptionButton>
             </OptionGroup>
@@ -129,11 +137,12 @@ const SleepTest = () => {
             <CodeBadge>{result.code}</CodeBadge>
             <CharacterArt>
               {result.image ? (
-                <CharacterImage src={result.image} alt={`${result.name} 캐릭터`} loading="lazy" />
+                <CharacterImage
+                  src={result.image}
+                  alt={`${result.name} 캐릭터`}
+                  loading="lazy"
+                />
               ) : null}
-              <CharacterEmoji role="img" aria-label="게 캐릭터">
-                {SLEEP_CHARACTER_EMOJI}
-              </CharacterEmoji>
             </CharacterArt>
             <ResultName>{result.name}</ResultName>
             <ResultDescription>{result.desc}</ResultDescription>
@@ -147,6 +156,7 @@ const SleepTest = () => {
               </PrimaryAction>
               <HomeAction to="/">홈으로</HomeAction>
             </ResultActions>
+            <SleepKakaoShareButton sleepResult={result} />
           </ResultCard>
         )}
       </Content>
@@ -154,7 +164,9 @@ const SleepTest = () => {
   );
 };
 
-const determineResult = (score: Record<SleepLetter, number>): SleepResultType => {
+const determineResult = (
+  score: Record<SleepLetter, number>
+): SleepResultType => {
   const code = AXIS_ORDER.map((axis) => {
     const [first, second] = AXIS_LETTER_MAP[axis];
     return score[first] >= score[second] ? first : second;
@@ -178,7 +190,7 @@ const determineResult = (score: Record<SleepLetter, number>): SleepResultType =>
 const PageWrapper = styled.div`
   min-height: 100vh;
   padding: clamp(2rem, 5vw, 4rem) clamp(1rem, 6vw, 3rem);
-  background: linear-gradient(160deg, #f7f8fb 0%, #f1f7ec 35%, #f8f0fb 100%);
+  width: 400px;
   display: flex;
   justify-content: center;
   align-items: flex-start;
@@ -207,7 +219,11 @@ const CardBase = styled.section`
 `;
 
 const IntroCard = styled(CardBase)`
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(247, 251, 243, 0.95) 100%);
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.95) 0%,
+    rgba(247, 251, 243, 0.95) 100%
+  );
 `;
 
 const IntroTitle = styled.h1`
@@ -245,6 +261,7 @@ const StartButton = styled.button`
 const QuizCard = styled(CardBase)`
   align-items: stretch;
   text-align: left;
+  width: 400px;
   gap: clamp(1.5rem, 3vw, 2rem);
 `;
 
@@ -298,11 +315,17 @@ const OptionButton = styled.button<{ $variant?: "outline" }>`
   padding: 1rem 1.25rem;
   font-size: 1.05rem;
   font-weight: 600;
-  border: ${({ $variant }) => ($variant === "outline" ? "2px solid #9ab6c0" : "none")};
-  background: ${({ $variant }) => ($variant === "outline" ? "#ffffff" : "linear-gradient(135deg, #9bd0b4 0%, #84b7f0 100%)")};
+  border: ${({ $variant }) =>
+    $variant === "outline" ? "2px solid #9ab6c0" : "none"};
+  background: ${({ $variant }) =>
+    $variant === "outline"
+      ? "#ffffff"
+      : "linear-gradient(135deg, #9bd0b4 0%, #84b7f0 100%)"};
   color: ${({ $variant }) => ($variant === "outline" ? "#5c708d" : "#ffffff")};
   box-shadow: ${({ $variant }) =>
-    $variant === "outline" ? "0 6px 16px rgba(154, 182, 192, 0.18)" : "0 12px 28px rgba(124, 176, 185, 0.3)"};
+    $variant === "outline"
+      ? "0 6px 16px rgba(154, 182, 192, 0.18)"
+      : "0 12px 28px rgba(124, 176, 185, 0.3)"};
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 
@@ -335,12 +358,17 @@ const CharacterArt = styled.div`
   width: clamp(160px, 40vw, 200px);
   height: clamp(160px, 40vw, 200px);
   border-radius: 36px;
-  background: linear-gradient(180deg, rgba(246, 255, 243, 0.9) 0%, rgba(211, 235, 255, 0.9) 100%);
+  background: linear-gradient(
+    180deg,
+    rgba(246, 255, 243, 0.9) 0%,
+    rgba(211, 235, 255, 0.9) 100%
+  );
   display: flex;
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  box-shadow: inset 0 0 0 6px rgba(255, 255, 255, 0.55), 0 20px 45px rgba(124, 161, 194, 0.25);
+  box-shadow: inset 0 0 0 6px rgba(255, 255, 255, 0.55),
+    0 20px 45px rgba(124, 161, 194, 0.25);
 `;
 
 const CharacterImage = styled.img`

--- a/src/pages/SleepTest.tsx
+++ b/src/pages/SleepTest.tsx
@@ -1,0 +1,449 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+import {
+  AXIS_LETTER_MAP,
+  AXIS_ORDER,
+  SLEEP_CHARACTER_EMOJI,
+  SLEEP_QUESTIONS,
+  SLEEP_RESULT_TYPES,
+  SleepLetter,
+  SleepResultType,
+} from "../constants/sleepTestData";
+
+type Stage = "intro" | "quiz" | "result";
+
+const INITIAL_SCORES: Record<SleepLetter, number> = {
+  F: 0,
+  L: 0,
+  M: 0,
+  Q: 0,
+  S: 0,
+  D: 0,
+  C: 0,
+  N: 0,
+};
+
+const SleepTest = () => {
+  const [stage, setStage] = useState<Stage>("intro");
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [scores, setScores] = useState<Record<SleepLetter, number>>({
+    ...INITIAL_SCORES,
+  });
+  const [result, setResult] = useState<SleepResultType | null>(null);
+
+  const totalQuestions = SLEEP_QUESTIONS.length;
+  const currentQuestion = SLEEP_QUESTIONS[currentIndex];
+
+  const progressPercent = useMemo(() => {
+    if (stage !== "quiz") {
+      return 0;
+    }
+
+    return Math.min((currentIndex / totalQuestions) * 100, 100);
+  }, [currentIndex, stage, totalQuestions]);
+
+  const handleStart = () => {
+    setStage("quiz");
+    setCurrentIndex(0);
+    setScores({ ...INITIAL_SCORES });
+    setResult(null);
+  };
+
+  const handleRestart = () => {
+    setStage("intro");
+    setCurrentIndex(0);
+    setScores({ ...INITIAL_SCORES });
+    setResult(null);
+  };
+
+  const handleAnswer = (isYes: boolean) => {
+    if (!currentQuestion) {
+      return;
+    }
+
+    const axisLetters = AXIS_LETTER_MAP[currentQuestion.axis];
+    const yesLetter = currentQuestion.yes;
+    const noLetter = axisLetters[0] === yesLetter ? axisLetters[1] : axisLetters[0];
+    const selectedLetter = isYes ? yesLetter : noLetter;
+
+    const updatedScores = {
+      ...scores,
+      [selectedLetter]: scores[selectedLetter] + 1,
+    };
+
+    const isLastQuestion = currentIndex + 1 === totalQuestions;
+
+    if (isLastQuestion) {
+      const finalResult = determineResult(updatedScores);
+      setScores(updatedScores);
+      setResult(finalResult);
+      setStage("result");
+    } else {
+      setScores(updatedScores);
+      setCurrentIndex((prev) => prev + 1);
+    }
+  };
+
+  return (
+    <PageWrapper>
+      <Content>
+        {stage === "intro" && (
+          <IntroCard>
+            <IntroTitle>🦀 수면구분법 테스트</IntroTitle>
+            <IntroDescription>
+              나는 어떤 잠버릇 타입일까? 총 16문항으로 알아보는 수면 성격 테스트!
+            </IntroDescription>
+            <StartButton type="button" onClick={handleStart}>
+              시작하기
+            </StartButton>
+          </IntroCard>
+        )}
+
+        {stage === "quiz" && currentQuestion && (
+          <QuizCard>
+            <ProgressBarWrapper>
+              <ProgressLabel>
+                {currentIndex + 1} / {totalQuestions}
+              </ProgressLabel>
+              <ProgressBar>
+                <ProgressFill $percent={progressPercent} />
+              </ProgressBar>
+            </ProgressBarWrapper>
+            <QuestionHeading>
+              Q{currentQuestion.id}. {currentQuestion.text}
+            </QuestionHeading>
+            <OptionGroup>
+              <OptionButton type="button" onClick={() => handleAnswer(true)}>
+                예
+              </OptionButton>
+              <OptionButton type="button" $variant="outline" onClick={() => handleAnswer(false)}>
+                아니오
+              </OptionButton>
+            </OptionGroup>
+          </QuizCard>
+        )}
+
+        {stage === "result" && result && (
+          <ResultCard>
+            <CodeBadge>{result.code}</CodeBadge>
+            <CharacterArt>
+              {result.image ? (
+                <CharacterImage src={result.image} alt={`${result.name} 캐릭터`} loading="lazy" />
+              ) : null}
+              <CharacterEmoji role="img" aria-label="게 캐릭터">
+                {SLEEP_CHARACTER_EMOJI}
+              </CharacterEmoji>
+            </CharacterArt>
+            <ResultName>{result.name}</ResultName>
+            <ResultDescription>{result.desc}</ResultDescription>
+            <TipSection>
+              <TipLabel>추천 수면 팁</TipLabel>
+              <TipText>{result.tip}</TipText>
+            </TipSection>
+            <ResultActions>
+              <PrimaryAction type="button" onClick={handleRestart}>
+                다시하기
+              </PrimaryAction>
+              <HomeAction to="/">홈으로</HomeAction>
+            </ResultActions>
+          </ResultCard>
+        )}
+      </Content>
+    </PageWrapper>
+  );
+};
+
+const determineResult = (score: Record<SleepLetter, number>): SleepResultType => {
+  const code = AXIS_ORDER.map((axis) => {
+    const [first, second] = AXIS_LETTER_MAP[axis];
+    return score[first] >= score[second] ? first : second;
+  }).join("");
+
+  const found = SLEEP_RESULT_TYPES.find((type) => type.code === code);
+
+  if (found) {
+    return found;
+  }
+
+  return {
+    code,
+    name: `${code} 게`,
+    desc: "아직 준비 중인 타입이에요! 곧 새로운 게 친구를 소개할게요.",
+    tip: "편안한 루틴을 기록하며 나만의 수면 습관을 만들어보세요.",
+    image: "",
+  };
+};
+
+const PageWrapper = styled.div`
+  min-height: 100vh;
+  padding: clamp(2rem, 5vw, 4rem) clamp(1rem, 6vw, 3rem);
+  background: linear-gradient(160deg, #f7f8fb 0%, #f1f7ec 35%, #f8f0fb 100%);
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+`;
+
+const Content = styled.main`
+  width: min(100%, 720px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(2rem, 4vw, 3rem);
+`;
+
+const CardBase = styled.section`
+  width: 100%;
+  background: rgba(255, 255, 255, 0.92);
+  border: 2px solid rgba(143, 177, 143, 0.25);
+  border-radius: 32px;
+  box-shadow: 0 24px 60px rgba(143, 177, 143, 0.18);
+  padding: clamp(1.75rem, 4vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: clamp(1.5rem, 3vw, 2.25rem);
+`;
+
+const IntroCard = styled(CardBase)`
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(247, 251, 243, 0.95) 100%);
+`;
+
+const IntroTitle = styled.h1`
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  color: #5b6c46;
+`;
+
+const IntroDescription = styled.p`
+  margin: 0;
+  max-width: 32rem;
+  font-size: clamp(1rem, 2.6vw, 1.2rem);
+  line-height: 1.6;
+  color: #6f7c5d;
+`;
+
+const StartButton = styled.button`
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 2.4rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+  background: linear-gradient(135deg, #a2c6a8 0%, #8fb1f2 100%);
+  color: #ffffff;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover,
+  &:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 30px rgba(143, 177, 143, 0.25);
+  }
+`;
+
+const QuizCard = styled(CardBase)`
+  align-items: stretch;
+  text-align: left;
+  gap: clamp(1.5rem, 3vw, 2rem);
+`;
+
+const ProgressBarWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+`;
+
+const ProgressLabel = styled.span`
+  align-self: flex-end;
+  font-size: 0.95rem;
+  color: #7c8c69;
+  letter-spacing: 0.02em;
+`;
+
+const ProgressBar = styled.div`
+  width: 100%;
+  height: 12px;
+  background: rgba(175, 193, 171, 0.25);
+  border-radius: 999px;
+  overflow: hidden;
+`;
+
+const ProgressFill = styled.div<{ $percent: number }>`
+  height: 100%;
+  width: ${({ $percent }) => $percent}%;
+  background: linear-gradient(135deg, #88c6c4 0%, #a3c7f0 100%);
+  border-radius: 999px;
+  transition: width 0.35s ease;
+`;
+
+const QuestionHeading = styled.h2`
+  margin: 0;
+  font-size: clamp(1.3rem, 3.2vw, 1.65rem);
+  color: #50614d;
+  line-height: 1.5;
+`;
+
+const OptionGroup = styled.div`
+  display: grid;
+  gap: 0.85rem;
+
+  @media (min-width: 520px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+`;
+
+const OptionButton = styled.button<{ $variant?: "outline" }>`
+  border-radius: 20px;
+  padding: 1rem 1.25rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+  border: ${({ $variant }) => ($variant === "outline" ? "2px solid #9ab6c0" : "none")};
+  background: ${({ $variant }) => ($variant === "outline" ? "#ffffff" : "linear-gradient(135deg, #9bd0b4 0%, #84b7f0 100%)")};
+  color: ${({ $variant }) => ($variant === "outline" ? "#5c708d" : "#ffffff")};
+  box-shadow: ${({ $variant }) =>
+    $variant === "outline" ? "0 6px 16px rgba(154, 182, 192, 0.18)" : "0 12px 28px rgba(124, 176, 185, 0.3)"};
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover,
+  &:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: ${({ $variant }) =>
+      $variant === "outline"
+        ? "0 10px 24px rgba(154, 182, 192, 0.2)"
+        : "0 16px 32px rgba(124, 176, 185, 0.32)"};
+  }
+`;
+
+const ResultCard = styled(CardBase)`
+  gap: clamp(1.25rem, 3vw, 1.75rem);
+`;
+
+const CodeBadge = styled.div`
+  padding: 0.35rem 1.4rem;
+  border-radius: 999px;
+  background: rgba(136, 198, 196, 0.28);
+  color: #517579;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+`;
+
+const CharacterArt = styled.div`
+  position: relative;
+  width: clamp(160px, 40vw, 200px);
+  height: clamp(160px, 40vw, 200px);
+  border-radius: 36px;
+  background: linear-gradient(180deg, rgba(246, 255, 243, 0.9) 0%, rgba(211, 235, 255, 0.9) 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 6px rgba(255, 255, 255, 0.55), 0 20px 45px rgba(124, 161, 194, 0.25);
+`;
+
+const CharacterImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  position: absolute;
+  inset: 0;
+`;
+
+const CharacterEmoji = styled.span`
+  font-size: clamp(4rem, 8vw, 5rem);
+  z-index: 1;
+`;
+
+const ResultName = styled.h3`
+  margin: 0;
+  font-size: clamp(1.6rem, 3.4vw, 2rem);
+  color: #50614d;
+`;
+
+const ResultDescription = styled.p`
+  margin: 0;
+  font-size: clamp(1rem, 2.5vw, 1.1rem);
+  color: #5f6f57;
+  line-height: 1.7;
+`;
+
+const TipSection = styled.div`
+  width: 100%;
+  background: rgba(241, 248, 235, 0.85);
+  border-radius: 24px;
+  padding: 1.1rem 1.4rem;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+`;
+
+const TipLabel = styled.span`
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  color: #7c8c69;
+  text-transform: uppercase;
+`;
+
+const TipText = styled.p`
+  margin: 0;
+  font-size: 1rem;
+  color: #50614d;
+  line-height: 1.6;
+`;
+
+const ResultActions = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+
+  @media (min-width: 520px) {
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+  }
+`;
+
+const PrimaryAction = styled.button`
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  background: linear-gradient(135deg, #8fd0b6 0%, #8aa9f5 100%);
+  color: #ffffff;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover,
+  &:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 28px rgba(138, 169, 245, 0.3);
+  }
+`;
+
+const HomeAction = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.85rem 2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #6a7d98;
+  background: #ffffff;
+  border: 2px solid rgba(139, 158, 191, 0.35);
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover,
+  &:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 26px rgba(139, 158, 191, 0.25);
+  }
+`;
+
+export default SleepTest;


### PR DESCRIPTION
## Summary
- add a sleep personality test flow with intro, quiz, and result pages at `/sleep-test`
- hardcode the 16-question survey and 16 crab sleep types including result copy and artwork assets
- link the new test from the arcade home screen navigation

## Testing
- yarn lint *(fails: missing `eslint` package in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d009b31c28832b9d9dcf0a2c9db122